### PR TITLE
Create combined audit summary for reports with no findings

### DIFF
--- a/audit/audit_plan_no_finding.md
+++ b/audit/audit_plan_no_finding.md
@@ -1,0 +1,30 @@
+# 审计计划报告汇总（无发现漏洞）
+
+下列审计计划均已按既定步骤执行，未发现实际漏洞。后续审计工作可避免重复以下思路：
+
+1. **Initialisable 重复初始化竞态分析**  
+   - 文件：`audit/audit_001_010_plan_report.md`
+   - 结论：Algorand 事务顺序执行保证 `initialise` 仅成功一次，未出现并发问题。
+2. **UInt64SetLib 边界条件与性能评估**  
+   - 文件：`audit/audit_001_011_plan_report.md`
+   - 结论：在 511 项上限下功能正常，推导显示无栈溢出或费用激增。
+3. **Upgradeable 合约程序哈希校验**  
+   - 文件：`audit/audit_001_012_plan_report.md`
+   - 结论：多页 SHA256 拼接方案正确，无法通过篡改单页绕过验证。
+4. **升级时间戳溢出检查**  
+   - 文件：`audit/audit_001_013_plan_report.md`
+   - 结论：时间范围远小于 `2^64`，溢出难以在现实中触发，合理配置即可避免风险。
+5. **AccessControl 角色 ID 碰撞概率评估**  
+   - 文件：`audit/audit_001_014_plan_report.md`
+   - 结论：当前仅少数角色，`keccak256` 截断 16 字节碰撞概率极低。
+6. **RateLimiter 桶重建导致配额重置验证**  
+   - 文件：`audit/audit_001_016_plan_report.md`
+   - 结论：删除后重建确实恢复满额，但接口未对外暴露，属可控行为。
+7. **升级后初始化抢占风险分析**  
+   - 文件：`audit/audit_001_017_plan_report.md`
+   - 结论：示例合约使用 `InitialisableWithCreator` 检查权限，未发现抢占漏洞。
+8. **升级调度覆盖及延迟绕过风险**  
+   - 文件：`audit/audit_001_018_plan_report.md`
+   - 结论：重新调度需满足当前最小延迟，无法提前升级。
+
+若需查看完整细节，可按上表中的文件路径查阅对应报告。


### PR DESCRIPTION
## Summary
- add `audit_plan_no_finding.md` summarising audit plans which reported no issues

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c98eaaf2c83288cc4c03bcf7fc85c