### PR TITLE
Add InitialisableWithCreator audit plan

### DIFF
--- a/audit/audit_001.md
+++ b/audit/audit_001.md
@@ -1,4 +1,4 @@
-# AI 审计方案 - 升级调度覆盖及延迟绕过风险
+# AI 审计方案 - 创建者限定初始化检查
 ## 更新历史
 - 2025-07-08: 基于 @audit_001_report_change_01.md、@audit_001_report.md、@audit_001_006_plan_report.md 等误报确认文件，本方案被人工否定，不再继续深挖。新审计方向详见 audit_001_010_plan.md。
 - 2025-07-09: 结合 @audit_001_access_control_plan_report.md 与 @audit_001_006_plan_report.md 的结果，确认旧方向均为误报。本方案再次停止，新的研究方向转向 UInt64SetLib 边界条件，详见 audit_001_011_plan.md。
@@ -12,26 +12,27 @@
 - 2025-07-17: audit_001_015_plan_report.md 证实桶管理与存储成本仅属设计考量，无安全漏洞，方向被人工否定。新的研究方向转向桶删除后立即重新创建是否可重置配额，计划文件为 audit_001_016_plan.md。
 - 2025-07-18: audit_001_016_plan_report.md 未发现漏洞，方向被人工否定。新的研究方向转向升级完成后初始化流程可能被抢占，计划文件为 audit_001_017_plan.md。
 - 2025-07-19: audit_001_017_plan_report.md 未发现漏洞，方向被人工否定。新的研究方向转向升级调度覆盖导致等待期被缩短的可能性，计划文件为 audit_001_018_plan.md。
+- 2025-07-20: audit_001_018_plan_report.md 未发现漏洞，方向被人工否定。参考 @audit_plan_false_finding.md 与 @audit_plan_no_finding.md，总结以往思路均未能挖掘实际问题，新的研究方向转向 `InitialisableWithCreator` 初始化权限，计划文件为 audit_001_019_plan.md。
 
 
 ## 背景
-审计确认升级完成后初始化流程不存在被抢占的实际风险，@audit_001_017_plan_report.md 已标记为人工否定。为继续探索潜在风险，本方案研究 **升级调度被多次覆盖从而缩短最小升级延迟** 的可能性。根据 `pk.md` 的先验知识，`RateLimiter` 的数值逻辑无需复查。
+`audit_001_018_plan_report.md` 进一步确认升级调度覆盖与延迟调整不存在漏洞，结合 `audit_plan_false_finding.md` 与 `audit_plan_no_finding.md` 中的结论，现有思路均已被人工否定。为寻找新的审计切入点，决定关注 **InitialisableWithCreator 扩展的初始化权限** 是否足够严格。根据 `pk.md` 的先验知识，`RateLimiter` 的数值逻辑无需复查。
 
 ## 审计目标
-1. 分析 `schedule_contract_upgrade` 重复调用是否能以更早的时间重新调度升级。
-2. 研究 `update_min_upgrade_delay` 在延迟尚未生效时再次调整的影响，判断是否可缩短等待时间。
-3. 设计测试场景验证二者结合是否会导致升级延迟被绕过。
-4. 基于结论给出文档或代码层面的改进建议。
+1. 审查 `InitialisableWithCreator.initialise` 对 `Global.creator_address` 的校验逻辑，确认无法被绕过。
+2. 评估在 Upgradeable 合约升级后，若新版本仍继承该扩展，是否可能利用旧状态或角色误用初始化入口。
+3. 设计测试场景验证仅合约创建者可以在任何阶段调用 `initialise`，并检查升级后是否仍受限制。
+4. 根据结果给出文档或代码层面的改进建议。
 
 ## 审计步骤
 1. **代码审查**
-   - 阅读 `schedule_contract_upgrade`、`update_min_upgrade_delay` 与 `_check_schedule_timestamp` 的实现。
-   - 推导在延迟修改未生效时再次调度的合法时间区间。
+   - 阅读 `InitialisableWithCreator` 与 `Initialisable` 的实现，确认 `initialise` 前置条件。
+   - 检查继承该扩展的示例合约或测试合约，确保未绕过权限检查。
 2. **测试设计**
-   - 构造场景：先设置较长延迟并调度升级，再在延迟生效前将延迟调低并重新调度，观察是否能提前完成升级。
+   - 构造场景：非创建者尝试调用 `initialise`，预期失败；升级合约后再次验证调用限制仍生效。
 3. **文档检查**
-   - 查看 README 与 DeepWiki 是否提醒开发者谨慎使用多次调度及延迟修改。
+   - 查看 README 与 DeepWiki 是否提示使用该扩展时需要注意的初始化权限。
 
 ## 预期结果
-- 评估升级调度覆盖是否会导致等待期被绕过。
+- 评估 `InitialisableWithCreator` 是否可靠地限制初始化仅由合约创建者执行。
 - 根据结论，将该方向标记为“未发现漏洞”或给出修复与文档建议。

--- a/audit/audit_001_019_plan.md
+++ b/audit/audit_001_019_plan.md
@@ -1,0 +1,29 @@
+# AI 审计方案 - 创建者限定初始化检查
+
+## 背景
+`audit_001_018_plan_report.md` 已确认升级调度相关的假设为误报。根据 `audit_plan_false_finding.md` 与 `audit_plan_no_finding.md` 的经验，本次计划转向 `InitialisableWithCreator` 扩展。该扩展在初始化时要求调用者必须是合约创建者，若实现或使用不当可能导致未授权的初始化。
+
+## 目标
+1. 验证 `InitialisableWithCreator.initialise` 对 `Global.creator_address` 的检查是否充分，没有被子类覆盖或绕过的风险。
+2. 评估在 `Upgradeable` 合约升级后，继承该扩展的新版本是否仍然只能由原始创建者初始化。
+3. 设计测试场景，确保非创建者在任何阶段均无法成功调用 `initialise`，包括升级后的合约。
+4. 根据审计结果提供必要的文档或代码改进建议。
+
+## 审计范围
+- `contracts/library/extensions/InitialisableWithCreator.py`
+- 继承该扩展的示例合约与测试代码
+- 与升级流程相关的 `Upgradeable` 实现
+
+## 方法与步骤
+1. **代码审查**
+   - 逐行检查 `InitialisableWithCreator` 的实现，确认 `initialise` 中的断言顺序和调用关系。
+   - 搜索仓库中所有继承该扩展的合约，确认其 `initialise` 实现均调用 `super().initialise()`。
+   - 了解 `Global.creator_address` 在升级后的取值是否保持不变，排除因升级导致的权限转移。
+2. **测试设计**
+   - 编写或修改现有测试，模拟非创建者调用 `initialise` 以及升级合约后的再次初始化，期望均被拒绝。
+3. **文档检查**
+   - 审阅 README 与 DeepWiki，确认是否对使用 `InitialisableWithCreator` 的限制做出明确说明。
+
+## 预期输出
+- 确认初始化权限仅限合约创建者，且在升级后依旧生效。
+- 若未发现问题，将该方向标记为人工否定；如有风险，提出修复建议并完善文档。


### PR DESCRIPTION
## Summary
- pivot audit_001.md to focus on InitialisableWithCreator
- record history for previous directions
- add new detailed plan `audit_001_019_plan.md`

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c9b2103248328b875db1538c07925