### PR TITLE
Add audit report for Upgradeable.version overflow

### DIFF
--- a/audit/audit_001_027_plan_report.md
+++ b/audit/audit_001_027_plan_report.md
@@ -1,0 +1,32 @@
+# 审计报告：`version` 溢出与升级次数限制
+
+## 执行摘要
+
+依据 `audit/audit_001_027_plan.md` 的步骤，我们检查了 `Upgradeable` 模块对版本号的管理方式以及 `UInt64` 的溢出可能。代码显示 `version` 在初始化时设为 1 并在升级后自增，没有任何上限检查或异常捕获【F:contracts/library/Upgradeable.py†L56-L61】【F:contracts/library/Upgradeable.py†L166-L171】。TEAL 和 Algopy 的 `UInt64` 均为 64 位无符号整数，达到 `2^64 - 1` 后再加 1 会回到 0。理论估算表明要执行 2^64 次升级需要难以置信的时间和成本，因此此风险仅属理论层面的治理注意事项。仓库文档未对升级次数或版本含义做额外说明【F:README.md†L1-L60】。
+
+## 详细审计过程
+
+### 1. 代码审查
+- `__init__` 中将 `version` 初始化为 `UInt64(1)`【F:contracts/library/Upgradeable.py†L56-L61】。
+- `complete_contract_upgrade` 执行完成后直接 `self.version += UInt64(1)`，无越界判断【F:contracts/library/Upgradeable.py†L166-L171】。
+- 全库搜索未发现针对 `version` 的边界检查或异常处理。
+- **微断言**：升级次数无限制，若达到 `2^64` 次将回绕。
+
+### 2. 理论推导
+- Algorand TEAL 的数值运算在 64 位无符号整数上执行；超出范围即以模 `2^64` 回绕。
+- 假设每次升级至少间隔一天（由 `min_upgrade_delay` 控制），达到 2^64 次需约 5.0e16 年。
+- 升级交易还需缴纳费用，成本同样呈指数级增长。
+- **微断言**：在正常运营周期内几乎不可能触及溢出阈值。
+
+### 3. 文档检查
+- `README.md` 主要介绍安装、编译与测试流程，没有提及版本号语义或升级上限【F:README.md†L1-L60】。
+- DeepWiki 链接因环境限制未能访问验证是否有相关说明。
+- **微断言**：官方文档未提醒开发者关注版本溢出，但鉴于其不可行性，这属低影响信息。
+
+## 结论
+
+- **无需立即防范**：虽然 `version` 最终会回绕，但所需升级次数远超现实场景，几乎不存在被利用的可能。
+- **治理提示**：若合约部署方计划进行极端频繁的升级，仍可在 `complete_contract_upgrade` 处加入 `assert self.version < MAX_UINT64` 等检查，并在文档中说明版本号仅作为升级计数器。
+- **测试覆盖**：现有测试仅验证版本递增【F:tests/library/Upgradeable.test.ts†L432-L459】，未关注溢出情况，可在未来增加模拟上限边界的单元测试以阐明理论行为。
+
+综上，本次审计认为 `version` 溢出属于理论风险，对实际安全性影响有限。维护者可在文档中简要说明版本号类型及其极限，以免引发误解。


### PR DESCRIPTION
## Summary
- add `audit_001_027_plan_report.md` detailing the analysis of possible overflow of the `version` field in `Upgradeable`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d251bf93c83288c72b91d1693c18e