### PR TITLE
Add audit report for plan 028

### DIFF
--- a/audit/audit_001_028_plan_report.md
+++ b/audit/audit_001_028_plan_report.md
@@ -1,0 +1,39 @@
+# 审计报告：升级程序页数上限与循环安全
+
+## 执行摘要
+
+依据 `audit/audit_001_028_plan.md` 制定的步骤，我们审查了 `Upgradeable.complete_contract_upgrade` 在遍历 `Txn.num_approval_program_pages` 与 `Txn.num_clear_state_program_pages` 时的行为。代码显示循环变量直接取自交易提供的页数，未做上限检查【F:contracts/library/Upgradeable.py†L157-L163】。
+
+Algorand 虚拟机每页最多 4096 字节，总程序大小上限为 8192 字节【F:contracts/library/Upgradeable.py†L38-L45】，因此理论上每种程序不超过两页。结合现有测试中构造的大型合约可知通常只需要 3 个额外页面即可覆盖极端情况【F:tests/library/Upgradeable.test.ts†L68-L75】。若交易恶意填入超大页数，循环次数会增加，但页数过大时交易本身即无法通过网络验证。实测受限于容器未安装 Algokit 与 Jest，无法运行单元测试【57c88b†L1-L8】。
+
+仓库的 README 未对程序页数或大小限制提供说明【F:README.md†L1-L60】，DeepWiki 链接因网络限制无法访问验证。整体来看，在 Algorand 协议已限制程序总大小的前提下，本函数遍历逻辑不会导致可行的拒绝服务。
+
+## 详细审计过程
+
+### 1. 代码审查
+- `complete_contract_upgrade` 首先拼接字符串 `"approval"`，随后按页遍历审批与清算程序计算哈希【F:contracts/library/Upgradeable.py†L157-L163】。
+- 该函数未检查 `Txn.num_*_program_pages` 的取值范围，也未限制循环次数。
+- **微断言**：若交易提供的页数超过允许值，将在构造程序哈希时进行同等次数的迭代。
+
+### 2. 理论分析
+- 注释指出 Algorand 程序总大小限定为 8192 字节，单页宽度 4096 字节【F:contracts/library/Upgradeable.py†L38-L45】。
+- 因此 `Txn.num_*_program_pages` 理论上上限为 2，合计不超过 4 次循环。
+- 交易若声称更多页数，其程序尺寸将超出协议限制，在节点验证阶段即会被拒绝。
+- **微断言**：在协议层面限制下，循环迭代次数无法被放大到导致资源枯竭的程度。
+
+### 3. 测试设计
+- 现有 `LargeContractToUpgradeTo` 合约通过冗长字节填充实现多页程序【F:contracts/library/test/LargeContractToUpgradeTo.py†L1-L8】。
+- `Upgradeable.test.ts` 部署该合约并指定 `extraProgramPages: 3`，覆盖了多页升级场景【F:tests/library/Upgradeable.test.ts†L68-L75】。
+- 由于容器缺乏 `jest`，执行 `npm run test` 报错 `jest: not found`【57c88b†L1-L8】，测试未能在本环境运行。
+- **微断言**：若在完整环境执行，测试应证明多页升级能正常完成，且无循环异常。
+
+### 4. 文档检查
+- `README.md` 只描述安装、编译和测试流程，未提及程序大小或页数限制【F:README.md†L1-L60】。
+- DeepWiki 参考文档无法访问，无法确认是否有额外说明。
+- **微断言**：缺乏文档可能导致开发者不清楚 Algorand 对程序大小的约束。
+
+## 结论
+
+- **未发现实际漏洞**：`complete_contract_upgrade` 的循环次数受 Algorand 协议的程序大小限制，理论上最多处理四个页面，难以造成 DoS。
+- **环境与文档不足**：测试依赖缺失导致无法验证极端场景，仓库文档亦未提醒页面上限。建议在 README 或 DeepWiki 中补充相关说明。
+- 综合而言，升级函数在现有协议约束下安全可靠，但加强文档与测试环境配置将更有利于开发者理解和验证其行为。


### PR DESCRIPTION
## Summary
- add report for audit plan 028 covering loop safety for page counts

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d28af2d448328af050861426e6946